### PR TITLE
Remove decorative emojis outside homepage features

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -38,7 +38,7 @@ const NotFound = () => (
   <div className="not-found-page">
     <div className="container">
       <div className="not-found-content">
-        <div className="not-found-icon">🤖</div>
+        <div className="not-found-icon" aria-hidden="true">404</div>
         <h1>404 - Page Not Found</h1>
         <p>The page you're looking for doesn't exist or has been moved.</p>
         <div className="not-found-actions">
@@ -52,7 +52,7 @@ const NotFound = () => (
             onClick={() => window.location.href = '/'}
             className="btn btn-primary"
           >
-            🏠 Go Home
+            Go Home
           </button>
         </div>
       </div>
@@ -65,10 +65,10 @@ function App() {
   // Initialize app and log startup info
   useEffect(() => {
     if (isDebugMode) {
-      console.log('🎤 Aura Voice AI App Started');
-      console.log('🌐 Environment:', process.env.REACT_APP_ENVIRONMENT);
-      console.log('🔗 API URL:', process.env.REACT_APP_API_BASE_URL);
-      console.log('📊 Debug Mode:', isDebugMode);
+      console.log('Aura Voice AI App Started');
+      console.log('Environment:', process.env.REACT_APP_ENVIRONMENT);
+      console.log('API URL:', process.env.REACT_APP_API_BASE_URL);
+      console.log('Debug Mode:', isDebugMode);
     }
 
     // Set up global app behaviors
@@ -86,12 +86,12 @@ function App() {
 
     // Handle online/offline status
     const handleOnline = () => {
-      if (isDebugMode) console.log('🌐 App is online');
+      if (isDebugMode) console.log('App is online');
       document.body.classList.remove('app-offline');
     };
 
     const handleOffline = () => {
-      if (isDebugMode) console.log('📡 App is offline');
+      if (isDebugMode) console.log('App is offline');
       document.body.classList.add('app-offline');
     };
 
@@ -122,7 +122,7 @@ function App() {
           {/* Offline status indicator */}
           <div className="offline-indicator">
             <div className="offline-message">
-              📡 You're offline. Some features may not work properly.
+              You're offline. Some features may not work properly.
             </div>
           </div>
 
@@ -194,7 +194,7 @@ function App() {
             <div className="container">
               <div className="footer-content">
                 <div className="footer-left">
-                  <span className="footer-logo">🎤 Aura Voice AI</span>
+                  <span className="footer-logo">Aura Voice AI</span>
                   <span className="footer-version">v{process.env.REACT_APP_VERSION}</span>
                 </div>
                 <div className="footer-right">
@@ -210,7 +210,7 @@ function App() {
           {isDevelopment && (
             <div className="dev-tools">
               <div className="dev-info">
-                <span>🔧 Dev Mode</span>
+                <span>Dev Mode</span>
                 <span>API: {process.env.REACT_APP_API_BASE_URL}</span>
               </div>
             </div>

--- a/src/components/auth/Login.js
+++ b/src/components/auth/Login.js
@@ -159,7 +159,6 @@ const Login = () => {
           {/* Header */}
           <div className="login-header">
             <Link to="/" className="logo-link">
-              <span className="logo-icon">🎤</span>
               <span className="logo-text">Aura</span>
             </Link>
             <h1 className="login-title">Welcome back</h1>
@@ -304,7 +303,7 @@ const Login = () => {
                 onClick={handleDemoLogin}
                 className="btn btn-secondary btn-sm w-full mt-3"
               >
-                🧪 Demo Login
+                Demo Login
               </button>
             )}
           </form>
@@ -323,7 +322,7 @@ const Login = () => {
         {/* Side Content (optional) */}
         <div className="login-side">
           <div className="side-content">
-            <div className="side-icon">🚀</div>
+            <div className="side-icon" aria-hidden="true">Insight</div>
             <h3 className="side-title">Join thousands of professionals</h3>
             <p className="side-description">
               Create intelligent voice AI assistants that understand your business 
@@ -332,17 +331,17 @@ const Login = () => {
             
             <div className="side-features">
               <div className="side-feature">
-                <span className="feature-check">✅</span>
+                <span className="feature-check" aria-hidden="true">•</span>
                 <span>Enterprise-grade security</span>
               </div>
-              <div className="side-feature">
-                <span className="feature-check">✅</span>
-                <span>Sub-2-second response times</span>
-              </div>
-              <div className="side-feature">
-                <span className="feature-check">✅</span>
-                <span>Custom personality training</span>
-              </div>
+                <div className="side-feature">
+                  <span className="feature-check" aria-hidden="true">•</span>
+                  <span>Sub-2-second response times</span>
+                </div>
+                <div className="side-feature">
+                  <span className="feature-check" aria-hidden="true">•</span>
+                  <span>Custom personality training</span>
+                </div>
             </div>
           </div>
         </div>
@@ -389,10 +388,6 @@ const Login = () => {
           gap: var(--space-2);
           text-decoration: none;
           margin-bottom: var(--space-6);
-        }
-
-        .logo-icon {
-          font-size: var(--text-3xl);
         }
 
         .logo-text {

--- a/src/components/auth/Register.js
+++ b/src/components/auth/Register.js
@@ -228,7 +228,7 @@ const Register = () => {
       <div className="register-page">
         <div className="success-container">
           <div className="success-card">
-            <div className="success-icon">✅</div>
+            <div className="success-icon" aria-hidden="true">Success</div>
             <h1 className="success-title">Registration Successful!</h1>
             <p className="success-message">
               Welcome to Aura! We've sent a confirmation email to <strong>{formData.email}</strong>. 
@@ -252,7 +252,6 @@ const Register = () => {
           {/* Header */}
           <div className="register-header">
             <Link to="/" className="logo-link">
-              <span className="logo-icon">🎤</span>
               <span className="logo-text">Aura</span>
             </Link>
             <h1 className="register-title">Create your account</h1>
@@ -544,7 +543,7 @@ const Register = () => {
         {/* Side Content */}
         <div className="register-side">
           <div className="side-content">
-            <div className="side-icon">🚀</div>
+            <div className="side-icon" aria-hidden="true">Insight</div>
             <h3 className="side-title">Build the future of voice AI</h3>
             <p className="side-description">
               Create intelligent voice assistants that understand your business, 
@@ -566,24 +565,24 @@ const Register = () => {
               </div>
             </div>
 
-            <div className="side-features">
-              <div className="side-feature">
-                <span className="feature-check">✅</span>
-                <span>Enterprise-grade security</span>
+              <div className="side-features">
+                <div className="side-feature">
+                  <span className="feature-check" aria-hidden="true">•</span>
+                  <span>Enterprise-grade security</span>
+                </div>
+                <div className="side-feature">
+                  <span className="feature-check" aria-hidden="true">•</span>
+                  <span>Custom personality training</span>
+                </div>
+                <div className="side-feature">
+                  <span className="feature-check" aria-hidden="true">•</span>
+                  <span>Real-time analytics</span>
+                </div>
+                <div className="side-feature">
+                  <span className="feature-check" aria-hidden="true">•</span>
+                  <span>Easy integration</span>
+                </div>
               </div>
-              <div className="side-feature">
-                <span className="feature-check">✅</span>
-                <span>Custom personality training</span>
-              </div>
-              <div className="side-feature">
-                <span className="feature-check">✅</span>
-                <span>Real-time analytics</span>
-              </div>
-              <div className="side-feature">
-                <span className="feature-check">✅</span>
-                <span>Easy integration</span>
-              </div>
-            </div>
           </div>
         </div>
       </div>
@@ -625,17 +624,13 @@ const Register = () => {
           margin-bottom: var(--space-6);
         }
 
-        .logo-link {
-          display: inline-flex;
-          align-items: center;
-          gap: var(--space-2);
-          text-decoration: none;
-          margin-bottom: var(--space-4);
-        }
-
-        .logo-icon {
-          font-size: var(--text-3xl);
-        }
+          .logo-link {
+            display: inline-flex;
+            align-items: center;
+            gap: var(--space-2);
+            text-decoration: none;
+            margin-bottom: var(--space-4);
+          }
 
         .logo-text {
           font-size: var(--text-2xl);

--- a/src/components/common/Navbar.js
+++ b/src/components/common/Navbar.js
@@ -93,7 +93,6 @@ const Navbar = () => {
           <div className="nav-content">
             {/* Logo */}
             <Link to="/" className="logo">
-              <span className="logo-icon">🎤</span>
               <span className="logo-text">Aura</span>
             </Link>
 
@@ -158,15 +157,12 @@ const Navbar = () => {
                       
                       <div className="user-menu-items">
                         <Link to="/dashboard" className="user-menu-item">
-                          <span className="menu-item-icon">📊</span>
                           Dashboard
                         </Link>
                         <Link to="/dashboard" className="user-menu-item">
-                          <span className="menu-item-icon">⚙️</span>
                           Settings
                         </Link>
                         <button onClick={handleLogout} className="user-menu-item logout-item">
-                          <span className="menu-item-icon">🚪</span>
                           Logout
                         </button>
                       </div>
@@ -238,15 +234,12 @@ const Navbar = () => {
                     
                     <div className="mobile-user-actions">
                       <Link to="/dashboard" className="mobile-menu-item">
-                        <span className="menu-item-icon">📊</span>
                         Dashboard
                       </Link>
                       <Link to="/dashboard" className="mobile-menu-item">
-                        <span className="menu-item-icon">⚙️</span>
                         Settings
                       </Link>
                       <button onClick={handleLogout} className="mobile-menu-item logout-item">
-                        <span className="menu-item-icon">🚪</span>
                         Logout
                       </button>
                     </div>
@@ -309,10 +302,6 @@ const Navbar = () => {
 
         .logo:hover {
           transform: scale(1.02);
-        }
-
-        .logo-icon {
-          font-size: var(--text-3xl);
         }
 
         .nav-center {
@@ -504,12 +493,6 @@ const Navbar = () => {
         .user-menu-item.logout-item:hover {
           background-color: var(--error-100);
           color: var(--error-500);
-        }
-
-        .menu-item-icon {
-          font-size: var(--text-lg);
-          width: 20px;
-          text-align: center;
         }
 
         /* Mobile Menu */

--- a/src/components/common/ProtectedRoute.js
+++ b/src/components/common/ProtectedRoute.js
@@ -150,7 +150,7 @@ const UnauthorizedAccess = ({ requiredRoles, userRole }) => (
               onClick={() => window.location.href = '/'}
               className="btn btn-primary w-full"
             >
-              🏠 Go Home
+              Go Home
             </button>
           </div>
         </div>
@@ -253,14 +253,14 @@ const EmailVerificationRequired = () => {
                     Sending...
                   </>
                 ) : (
-                  '📧 Resend Verification Email'
+                  'Resend Verification Email'
                 )}
               </button>
               <button
                 onClick={() => window.location.href = '/'}
                 className="btn btn-secondary w-full"
               >
-                🏠 Go Home
+                Go Home
               </button>
             </div>
             

--- a/src/components/dashboard/Dashboard.js
+++ b/src/components/dashboard/Dashboard.js
@@ -85,11 +85,11 @@ const Dashboard = () => {
   };
 
   const tabs = [
-    { id: 'overview', label: 'Overview', icon: '📊', component: DashboardOverview },
-    { id: 'training', label: 'Training Content', icon: '🧠', component: TrainingDashboard },
-    { id: 'analytics', label: 'Analytics', icon: '📈', component: AnalyticsTab },
-    { id: 'widget', label: 'Widget Code', icon: '🧩', component: WidgetGenerator },
-    { id: 'settings', label: 'Settings', icon: '⚙️', component: SettingsTab }
+    { id: 'overview', label: 'Overview', component: DashboardOverview },
+    { id: 'training', label: 'Training Content', component: TrainingDashboard },
+    { id: 'analytics', label: 'Analytics', component: AnalyticsTab },
+    { id: 'widget', label: 'Widget Code', component: WidgetGenerator },
+    { id: 'settings', label: 'Settings', component: SettingsTab }
   ];
 
   const handleSignOut = async () => {
@@ -177,7 +177,6 @@ const Dashboard = () => {
               onClick={() => setActiveTab(tab.id)}
               className={`tab-button ${activeTab === tab.id ? 'active' : ''}`}
             >
-              <span className="tab-icon">{tab.icon}</span>
               <span className="tab-label">{tab.label}</span>
             </button>
           ))}
@@ -277,10 +276,6 @@ const Dashboard = () => {
           color: var(--primary-600);
           background: var(--white);
           border-bottom: 2px solid var(--primary-600);
-        }
-
-        .tab-icon {
-          font-size: var(--text-lg);
         }
 
         .tab-content {

--- a/src/components/dashboard/DashboardOverview.js
+++ b/src/components/dashboard/DashboardOverview.js
@@ -47,26 +47,22 @@ const DashboardOverview = ({ user, dashboardData, onRefresh }) => {
     {
       label: 'Conversations',
       value: formatNumber(totalConversations),
-      helper: 'Sessions captured in Supabase',
-      icon: '💬'
+      helper: 'Sessions captured in Supabase'
     },
     {
       label: 'Reference Files',
       value: formatNumber(totalDocuments),
-      helper: 'Documents available for retrieval',
-      icon: '📄'
+      helper: 'Documents available for retrieval'
     },
     {
       label: 'Manual Q&A',
       value: formatNumber(totalQAPairs),
-      helper: 'Prompt / response pairs',
-      icon: '🗂️'
+      helper: 'Prompt / response pairs'
     },
     {
       label: 'Logic Notes',
       value: formatNumber(totalLogicNotes),
-      helper: 'Behavioral rules & guidance',
-      icon: '🧠'
+      helper: 'Behavioral rules & guidance'
     }
   ];
 
@@ -108,7 +104,7 @@ const DashboardOverview = ({ user, dashboardData, onRefresh }) => {
       <div className="stats-grid">
         {overviewCards.map((card) => (
           <div key={card.label} className="stat-card">
-            <div className="stat-icon">{card.icon}</div>
+            <div className="stat-icon" aria-hidden="true">{card.label.charAt(0)}</div>
             <div>
               <div className="stat-value">{card.value}</div>
               <div className="stat-label">{card.label}</div>
@@ -135,7 +131,7 @@ const DashboardOverview = ({ user, dashboardData, onRefresh }) => {
         </div>
         {recentActivity.length === 0 ? (
           <div className="empty-state">
-            <span className="empty-icon">📭</span>
+            <span className="empty-icon" aria-hidden="true">No Data</span>
             <p>No recent conversations recorded.</p>
             <p className="empty-helper">Start a new session or add training content to see it here.</p>
           </div>

--- a/src/components/dashboard/TrainingDashboard.js
+++ b/src/components/dashboard/TrainingDashboard.js
@@ -517,26 +517,22 @@ const TrainingDashboard = ({ user, supabase, updateDashboardData, onRefresh }) =
     {
       label: 'Q&A Pairs',
       value: formatNumber(totalQAPairs),
-      helper: 'Manual prompt / response entries',
-      icon: '💬'
+      helper: 'Manual prompt / response entries'
     },
     {
       label: 'Reference Files',
       value: formatNumber(totalReferenceFiles),
-      helper: 'Documents stored in Supabase',
-      icon: '📄'
+      helper: 'Documents stored in Supabase'
     },
     {
       label: 'Logic Notes',
       value: formatNumber(totalLogicNotes),
-      helper: 'Conversation rules & guardrails',
-      icon: '🧠'
+      helper: 'Conversation rules & guardrails'
     },
     {
       label: 'Unique Tags',
       value: formatNumber(uniqueTags.size),
-      helper: 'Topics applied across training',
-      icon: '🏷️'
+      helper: 'Topics applied across training'
     }
   ];
 
@@ -586,7 +582,7 @@ const TrainingDashboard = ({ user, supabase, updateDashboardData, onRefresh }) =
         </div>
       ) : trainingData.length === 0 ? (
         <div className="empty-state">
-          <div className="empty-icon">💬</div>
+          <div className="empty-icon" aria-hidden="true">Q&amp;A</div>
           <h4>No Q&amp;A pairs yet</h4>
           <p>Click "Add Q&amp;A Pair" to create your first prompt-response pair.</p>
         </div>
@@ -621,10 +617,10 @@ const TrainingDashboard = ({ user, supabase, updateDashboardData, onRefresh }) =
                   <td>
                     <div className="table-actions">
                       <button className="icon-btn" onClick={() => handleQADialogOpen(item)} title="Edit">
-                        ✏️
+                        Edit
                       </button>
                       <button className="icon-btn" onClick={() => handleQADelete(item.id)} title="Delete">
-                        🗑️
+                        Delete
                       </button>
                     </div>
                   </td>
@@ -646,7 +642,7 @@ const TrainingDashboard = ({ user, supabase, updateDashboardData, onRefresh }) =
         </div>
         <label className={`btn primary ${isUploading ? 'disabled' : ''}`}>
           <input type="file" accept=".pdf,.docx,.txt,.md" onChange={handleFileUpload} disabled={isUploading} />
-          <span className="icon">📁</span>
+          <span className="icon" aria-hidden="true">File</span>
           {isUploading ? `Uploading… ${uploadProgress}%` : 'Upload File'}
         </label>
       </div>
@@ -657,7 +653,7 @@ const TrainingDashboard = ({ user, supabase, updateDashboardData, onRefresh }) =
         </div>
       ) : referenceMaterials.length === 0 ? (
         <div className="empty-state">
-          <div className="empty-icon">📄</div>
+          <div className="empty-icon" aria-hidden="true">Docs</div>
           <h4>No reference materials yet</h4>
           <p>Upload documents to build Aura's knowledge base.</p>
         </div>
@@ -683,7 +679,7 @@ const TrainingDashboard = ({ user, supabase, updateDashboardData, onRefresh }) =
                   <td>
                     <div className="table-actions">
                       <button className="icon-btn" onClick={() => handleDeleteMaterial(item)} title="Delete">
-                        🗑️
+                        Delete
                       </button>
                     </div>
                   </td>
@@ -715,7 +711,7 @@ const TrainingDashboard = ({ user, supabase, updateDashboardData, onRefresh }) =
         </div>
       ) : logicNotes.length === 0 ? (
         <div className="empty-state">
-          <div className="empty-icon">🧠</div>
+          <div className="empty-icon" aria-hidden="true">Logic</div>
           <h4>No logic notes yet</h4>
           <p>Define guidance and behavioral rules for Aura.</p>
         </div>
@@ -733,10 +729,10 @@ const TrainingDashboard = ({ user, supabase, updateDashboardData, onRefresh }) =
                 </div>
                 <div className="table-actions">
                   <button className="icon-btn" onClick={() => handleLogicDialogOpen(item)} title="Edit">
-                    ✏️
+                    Edit
                   </button>
                   <button className="icon-btn" onClick={() => handleLogicDelete(item.id)} title="Delete">
-                    🗑️
+                    Delete
                   </button>
                 </div>
               </div>
@@ -784,7 +780,7 @@ const TrainingDashboard = ({ user, supabase, updateDashboardData, onRefresh }) =
       <div className="summary-grid">
         {summaryCards.map(card => (
           <div key={card.label} className="summary-card">
-            <div className="summary-icon">{card.icon}</div>
+            <div className="summary-icon" aria-hidden="true">{card.label.charAt(0)}</div>
             <div>
               <div className="summary-value">{card.value}</div>
               <div className="summary-label">{card.label}</div>
@@ -806,13 +802,13 @@ const TrainingDashboard = ({ user, supabase, updateDashboardData, onRefresh }) =
 
       <div className="tabs">
         <button className={`tab-button ${activeTab === 'qa' ? 'active' : ''}`} onClick={() => setActiveTab('qa')}>
-          💬 Manual Training
+          Manual Training
         </button>
         <button className={`tab-button ${activeTab === 'materials' ? 'active' : ''}`} onClick={() => setActiveTab('materials')}>
-          📄 Reference Materials
+          Reference Materials
         </button>
         <button className={`tab-button ${activeTab === 'logic' ? 'active' : ''}`} onClick={() => setActiveTab('logic')}>
-          🧠 Logic Notes
+          Logic Notes
         </button>
       </div>
 

--- a/src/components/explore/ExplorePage.js
+++ b/src/components/explore/ExplorePage.js
@@ -266,7 +266,7 @@ const ExplorePage = () => {
           {!isAuthenticated && (
             <div className="header-cta">
               <Link to="/register" className="btn btn-primary">
-                🎤 Create Your AI
+                Create Your AI
               </Link>
             </div>
           )}
@@ -351,7 +351,7 @@ const ExplorePage = () => {
             </div>
           ) : filteredAndSortedChatbots.length === 0 ? (
             <div className="empty-state">
-              <div className="empty-icon">🔍</div>
+              <div className="empty-icon" aria-hidden="true">No Results</div>
               <h3 className="empty-title">No AI assistants found</h3>
               <p className="empty-message">
                 Try adjusting your search terms or filters to find what you're looking for.
@@ -635,11 +635,11 @@ const ChatbotCard = ({ chatbot }) => {
       </div>
 
       <div className="card-footer">
-        <Link 
+        <Link
           to={`/chat/${chatbot.slug}`}
           className="btn btn-primary w-full"
         >
-          💬 Start Conversation
+          Start Conversation
         </Link>
       </div>
 

--- a/src/components/explore/UserCard.js
+++ b/src/components/explore/UserCard.js
@@ -49,20 +49,11 @@ const UserCard = ({ user, onChatClick, showActions = true, compact = false }) =>
   };
 
   /**
-   * Get personality emoji based on personality type
+   * Format personality label for display
    */
-  const getPersonalityEmoji = (personality) => {
-    const emojiMap = {
-      friendly: '😊',
-      professional: '💼',
-      creative: '🎨',
-      technical: '🔧',
-      casual: '😎',
-      energetic: '⚡',
-      calm: '🧘',
-      witty: '😄'
-    };
-    return emojiMap[personality] || '🤖';
+  const getPersonalityLabel = (personality) => {
+    if (!personality) return 'Personality';
+    return personality.charAt(0).toUpperCase() + personality.slice(1);
   };
 
   /**
@@ -141,12 +132,12 @@ const UserCard = ({ user, onChatClick, showActions = true, compact = false }) =>
         </div>
 
         <div className="card-actions">
-          <button 
+          <button
             className="chat-btn primary"
             onClick={handleChatClick}
             title="Start chat"
           >
-            💬
+            Chat
           </button>
         </div>
       </div>
@@ -195,7 +186,7 @@ const UserCard = ({ user, onChatClick, showActions = true, compact = false }) =>
           <div className="name-section">
             <h3>{userData.name}</h3>
             <span className="personality-indicator">
-              {getPersonalityEmoji(userData.personality)}
+              {getPersonalityLabel(userData.personality)}
             </span>
           </div>
           
@@ -205,7 +196,7 @@ const UserCard = ({ user, onChatClick, showActions = true, compact = false }) =>
             <span className="online-status">{formatLastActive()}</span>
             {userData.voiceEnabled && (
               <span className="voice-enabled" title="Voice chat available">
-                🎤
+                Voice
               </span>
             )}
           </div>
@@ -264,7 +255,6 @@ const UserCard = ({ user, onChatClick, showActions = true, compact = false }) =>
             className="btn primary"
             onClick={handleChatClick}
           >
-            <span>💬</span>
             Start Chat
           </button>
         </div>

--- a/src/components/explore/VoiceChat.js
+++ b/src/components/explore/VoiceChat.js
@@ -419,13 +419,13 @@ const VoiceChat = () => {
               className={`btn btn-primary btn-lg voice-btn ${isRecording ? 'recording' : ''}`}
             >
               {isRecording ? (
-                <>🎙️ Recording...</>
+                <>Recording...</>
               ) : (
-                <>📞 Call</>
+                <>Start Call</>
               )}
             </button>
             <button className="btn btn-secondary btn-lg">
-              💬 Chat
+              Open Chat
             </button>
           </div>
         </div>
@@ -442,7 +442,7 @@ const VoiceChat = () => {
                   onClick={() => handleQuestionClick(question)}
                   className="question-card"
                 >
-                  <span className="question-icon">💡</span>
+                  <span className="question-icon" aria-hidden="true">Q</span>
                   <span className="question-text">{question}</span>
                 </button>
               ))}

--- a/src/components/home/Homepage.js
+++ b/src/components/home/Homepage.js
@@ -27,7 +27,6 @@ const Homepage = () => {
         <div className="container">
           <div className={`hero-content ${isVisible ? 'animate-in' : ''}`}>
             <div className="hero-badge">
-              <span className="badge-icon">🚀</span>
               <span className="badge-text">Next-Generation Voice AI</span>
             </div>
             
@@ -55,10 +54,10 @@ const Homepage = () => {
               ) : (
                 <>
                   <Link to="/register" className="btn btn-primary btn-lg">
-                    🎤 Start Building
+                    Start Building
                   </Link>
                   <Link to="/explore" className="btn btn-secondary btn-lg">
-                    👁️ See Demo
+                    See Demo
                   </Link>
                 </>
               )}
@@ -360,10 +359,6 @@ const Homepage = () => {
           font-weight: var(--font-weight-medium);
           margin-bottom: var(--space-6);
           border: 1px solid var(--primary-200);
-        }
-
-        .badge-icon {
-          font-size: var(--text-base);
         }
 
         .hero-title {

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -51,7 +51,7 @@ const ActionTypes = {
 // Auth reducer
 function authReducer(state, action) {
   if (isDebugMode) {
-    console.log('🔐 Auth Action:', action.type, action.payload);
+    console.log('Auth Action:', action.type, action.payload);
   }
 
   switch (action.type) {
@@ -172,7 +172,7 @@ export const AuthProvider = ({ children }) => {
     const { data: { subscription } } = supabase.auth.onAuthStateChange(
       async (event, session) => {
         if (isDebugMode) {
-          console.log('🔐 Supabase auth event:', event, session);
+          console.log('Supabase auth event:', event, session);
         }
 
         if (session?.user) {
@@ -240,27 +240,26 @@ export const AuthProvider = ({ children }) => {
       if (error) throw error;
 
       if (isDebugMode) {
-        console.log('✅ Sign up successful:', data);
+        console.log('Sign up successful:', data);
       }
 
-      return { 
-        success: true, 
+      return {
+        success: true,
         user: data.user,
-        message: data.user?.email_confirmed_at 
+        message: data.user?.email_confirmed_at
           ? 'Account created successfully!'
           : 'Please check your email to confirm your account.'
       };
-
     } catch (error) {
       const errorMessage = error.message || 'Sign up failed. Please try again.';
-      
+
       dispatch({
         type: ActionTypes.SET_ERROR,
         payload: errorMessage
       });
 
       if (isDebugMode) {
-        console.error('❌ Sign up failed:', error);
+        console.error('Sign up failed:', error);
       }
 
       return { success: false, error: errorMessage };
@@ -280,21 +279,20 @@ export const AuthProvider = ({ children }) => {
       if (error) throw error;
 
       if (isDebugMode) {
-        console.log('✅ Sign in successful:', data.user);
+        console.log('Sign in successful:', data.user);
       }
 
       return { success: true, user: data.user };
-
     } catch (error) {
       const errorMessage = error.message || 'Sign in failed. Please try again.';
-      
+
       dispatch({
         type: ActionTypes.SET_ERROR,
         payload: errorMessage
       });
 
       if (isDebugMode) {
-        console.error('❌ Sign in failed:', error);
+        console.error('Sign in failed:', error);
       }
 
       return { success: false, error: errorMessage };
@@ -316,14 +314,13 @@ export const AuthProvider = ({ children }) => {
       if (error) throw error;
 
       if (isDebugMode) {
-        console.log('✅ Google sign in initiated');
+        console.log('Google sign in initiated');
       }
 
       return { success: true };
-
     } catch (error) {
       const errorMessage = error.message || 'Google sign in failed. Please try again.';
-      
+
       dispatch({
         type: ActionTypes.SET_ERROR,
         payload: errorMessage
@@ -337,17 +334,16 @@ export const AuthProvider = ({ children }) => {
   const signOut = async () => {
     try {
       const { error } = await supabase.auth.signOut();
-      
+
       if (error) {
         console.error('Sign out error:', error);
       }
 
       if (isDebugMode) {
-        console.log('✅ Sign out successful');
+        console.log('Sign out successful');
       }
 
       return { success: true };
-
     } catch (error) {
       console.error('Sign out failed:', error);
       return { success: false, error: error.message };

--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,7 @@ class ErrorBoundary extends React.Component {
           padding: '2rem',
           fontFamily: 'Inter, -apple-system, BlinkMacSystemFont, sans-serif'
         }}>
-          <div style={{ fontSize: '4rem', marginBottom: '1rem' }}>🎤</div>
+          <div style={{ fontSize: '4rem', marginBottom: '1rem' }}>Aura</div>
           <h1 style={{ fontSize: '2rem', marginBottom: '1rem' }}>
             Oops! Something went wrong
           </h1>
@@ -74,7 +74,7 @@ class ErrorBoundary extends React.Component {
                 transition: 'all 0.3s ease'
               }}
             >
-              🔄 Refresh Page
+              Refresh Page
             </button>
             <button
               onClick={() => window.location.href = '/'}
@@ -89,7 +89,7 @@ class ErrorBoundary extends React.Component {
                 transition: 'all 0.3s ease'
               }}
             >
-              🏠 Go Home
+              Go Home
             </button>
           </div>
           
@@ -105,7 +105,7 @@ class ErrorBoundary extends React.Component {
               fontSize: '0.9rem'
             }}>
               <summary style={{ cursor: 'pointer', marginBottom: '1rem' }}>
-                🐛 Error Details (Development Mode)
+                Error Details (Development Mode)
               </summary>
               <pre style={{ whiteSpace: 'pre-wrap', overflow: 'auto' }}>
                 {this.state.error && this.state.error.toString()}
@@ -130,7 +130,7 @@ function measurePerformance() {
       const perfData = performance.getEntriesByType('navigation')[0];
       
       if (isDebugMode) {
-        console.log('🚀 Performance Metrics:');
+          console.log('Performance Metrics:');
         console.log(`- DOM Content Loaded: ${perfData.domContentLoadedEventEnd - perfData.domContentLoadedEventStart}ms`);
         console.log(`- Page Load Complete: ${perfData.loadEventEnd - perfData.loadEventStart}ms`);
         console.log(`- Total Load Time: ${perfData.loadEventEnd - perfData.fetchStart}ms`);
@@ -147,7 +147,7 @@ function measurePerformance() {
         const lastEntry = entries[entries.length - 1];
         
         if (isDebugMode) {
-          console.log(`📊 LCP: ${lastEntry.startTime}ms`);
+          console.log(`LCP: ${lastEntry.startTime}ms`);
         }
       });
       
@@ -162,7 +162,7 @@ function initializeApp() {
   const container = document.getElementById('root');
   
   if (!container) {
-    console.error('❌ Could not find root element. Make sure your HTML has <div id="root"></div>');
+    console.error('Could not find root element. Make sure your HTML has <div id="root"></div>');
     return;
   }
 
@@ -171,17 +171,17 @@ function initializeApp() {
 
   // Development mode enhancements
   if (isDevelopment) {
-    console.log('🎤 Aura Voice AI - Development Mode');
-    console.log('📊 Debug mode:', isDebugMode);
-    console.log('🔧 Environment variables loaded:', {
+    console.log('Aura Voice AI - Development Mode');
+    console.log('Debug mode:', isDebugMode);
+    console.log('Environment variables loaded:', {
       API_URL: process.env.REACT_APP_API_BASE_URL,
-      SUPABASE_URL: process.env.REACT_APP_SUPABASE_URL ? '✅ Set' : '❌ Missing',
+      SUPABASE_URL: process.env.REACT_APP_SUPABASE_URL ? 'Set' : 'Missing',
       DEBUG_MODE: isDebugMode
     });
 
     // Enable React DevTools profiler
     if (window.__REACT_DEVTOOLS_GLOBAL_HOOK__) {
-      console.log('🔍 React DevTools detected');
+      console.log('React DevTools detected');
     }
   }
 
@@ -212,7 +212,7 @@ function initializeApp() {
 
   // Log successful initialization
   if (isDebugMode) {
-    console.log('✅ Aura Voice AI initialized successfully');
+    console.log('Aura Voice AI initialized successfully');
   }
 }
 
@@ -243,10 +243,10 @@ if ('serviceWorker' in navigator && !isDevelopment) {
   window.addEventListener('load', () => {
     navigator.serviceWorker.register('/service-worker.js')
       .then((registration) => {
-        console.log('✅ Service Worker registered:', registration.scope);
+        console.log('Service Worker registered:', registration.scope);
       })
       .catch((registrationError) => {
-        console.log('❌ Service Worker registration failed:', registrationError);
+        console.log('Service Worker registration failed:', registrationError);
       });
   });
 }
@@ -257,7 +257,7 @@ initializeApp();
 // Hot module replacement for development
 if (isDevelopment && module.hot) {
   module.hot.accept('./App', () => {
-    console.log('🔄 Hot reloading App component');
+    console.log('Hot reloading App component');
     initializeApp();
   });
 }

--- a/src/services/voiceService.js
+++ b/src/services/voiceService.js
@@ -43,11 +43,11 @@ class VoiceService {
 
       // Start recording
       this.mediaRecorder.start(100); // Collect data every 100ms
-      console.log('🎤 Voice recording started');
+      console.log('Voice recording started');
       
       return true;
     } catch (error) {
-      console.error('❌ Error starting recording:', error);
+      console.error('Error starting recording:', error);
       this.isRecording = false;
       return false;
     }
@@ -67,7 +67,7 @@ class VoiceService {
       this.mediaRecorder.onstop = () => {
         const audioBlob = new Blob(this.audioChunks, { type: 'audio/webm' });
         this.cleanup();
-        console.log('🛑 Voice recording stopped');
+        console.log('Voice recording stopped');
         resolve(audioBlob);
       };
 
@@ -107,10 +107,10 @@ class VoiceService {
         },
       });
 
-      console.log('📝 Speech-to-text completed:', response.data.text);
+      console.log('Speech-to-text completed:', response.data.text);
       return response.data.text || '';
     } catch (error) {
-      console.error('❌ Speech-to-text error:', error);
+      console.error('Speech-to-text error:', error);
       return '';
     }
   }
@@ -134,12 +134,12 @@ class VoiceService {
       });
 
       if (response.data.audio_url) {
-        console.log('🔊 Text-to-speech completed');
+        console.log('Text-to-speech completed');
         return response.data.audio_url;
       }
       return null;
     } catch (error) {
-      console.error('❌ Text-to-speech error:', error);
+      console.error('Text-to-speech error:', error);
       return null;
     }
   }
@@ -156,19 +156,19 @@ class VoiceService {
       
       return new Promise((resolve, reject) => {
         audio.onended = () => {
-          console.log('🔊 Audio playback completed');
+          console.log('Audio playback completed');
           resolve();
         };
         
         audio.onerror = (error) => {
-          console.error('❌ Audio playback error:', error);
+      console.error('Audio playback error:', error);
           reject(error);
         };
         
         audio.play();
       });
     } catch (error) {
-      console.error('❌ Error playing audio:', error);
+      console.error('Error playing audio:', error);
       throw error;
     }
   }
@@ -182,7 +182,7 @@ class VoiceService {
    */
   async voiceChat(userSlug, onTranscription = null, onResponse = null) {
     try {
-      console.log('🎤 Starting voice chat with user:', userSlug);
+      console.log('Starting voice chat with user:', userSlug);
 
       // Start recording
       const recordingStarted = await this.startRecording();
@@ -231,7 +231,7 @@ class VoiceService {
         }
       };
     } catch (error) {
-      console.error('❌ Voice chat error:', error);
+      console.error('Voice chat error:', error);
       this.cleanup();
       throw error;
     }

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -388,8 +388,9 @@
 }
 
 .tip-item::before {
-  content: '💡';
-  font-size: 16px;
+  content: 'Tip';
+  font-size: 14px;
+  font-weight: 600;
   flex-shrink: 0;
   margin-top: 2px;
 }


### PR DESCRIPTION
## Summary
- remove emoji-based icons from the hero CTA, offline banner, navbar, and other layout elements while keeping the Why Choose Aura icons intact
- update dashboard and training surfaces to rely on textual labels for tabs, summary cards, empty states, and CSS tips
- replace emoji usage across auth pages, explore views, voice chat UI, and voice service logs with descriptive text

## Testing
- npm install *(fails: 403 Forbidden retrieving @supabase/supabase-js)*

------
https://chatgpt.com/codex/tasks/task_e_68cef77a73ac83339cda80703eec2f9f