### PR TITLE
Fix explore chatbot loading, guard voice call flow, and repair profile navigation

### DIFF
--- a/src/components/explore/ExplorePage.js
+++ b/src/components/explore/ExplorePage.js
@@ -63,7 +63,7 @@ const ExplorePage = () => {
     try {
       const { data, error } = await supabase
         .from('profiles')
-        .select('id, full_name, username, email, bio, title, avatar_url, avatar_path, created_at')
+        .select('id, full_name, username, email, bio, title, avatar_path, created_at')
         .order('created_at', { ascending: false })
         .limit(100);
 
@@ -149,7 +149,7 @@ const ExplorePage = () => {
       }
 
       if (!tenantUsers || tenantUsers.length === 0) {
-        setChatbots([]);
+        await fetchProfilesDirectory();
         setError(null);
         return;
       }
@@ -184,7 +184,7 @@ const ExplorePage = () => {
             .in('user_id', userIds),
           supabase
             .from('profiles')
-            .select('id, username, full_name, email, bio, title, avatar_url, avatar_path, created_at')
+            .select('id, username, full_name, email, bio, title, avatar_path, created_at')
             .in('id', userIds)
         ]);
 
@@ -351,8 +351,12 @@ const ExplorePage = () => {
         };
       });
 
-      setChatbots(processedChatbots);
-      setError(null);
+      if (processedChatbots.length === 0) {
+        await fetchProfilesDirectory();
+      } else {
+        setChatbots(processedChatbots);
+        setError(null);
+      }
     } catch (err) {
       setError('Failed to load chatbots. Please try again.');
       console.error('Error fetching chatbots:', err);

--- a/src/components/explore/VoiceChat.js
+++ b/src/components/explore/VoiceChat.js
@@ -1,7 +1,7 @@
 // Aura Voice AI - Individual Profile & Voice Chat Component
 // =========================================================
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useAuth } from '../../context/AuthContext';
 import LoadingSpinner from '../common/LoadingSpinner';
@@ -19,7 +19,7 @@ const PROFILE_BUCKET = process.env.REACT_APP_SUPABASE_AVATAR_BUCKET || 'avatars'
 const VoiceChat = () => {
   const { slug } = useParams();
   const navigate = useNavigate();
-  const { supabase } = useAuth();
+  const { supabase, isAuthenticated } = useAuth();
 
   // State management
   const [profile, setProfile] = useState(null);
@@ -30,6 +30,36 @@ const VoiceChat = () => {
   const [messages, setMessages] = useState([]);
   const [questionInput, setQuestionInput] = useState('');
   const [avatarError, setAvatarError] = useState(false);
+  const [showLoginPrompt, setShowLoginPrompt] = useState(false);
+  const [callStatus, setCallStatus] = useState('idle');
+  const [isMuted, setIsMuted] = useState(false);
+  const callTimerRef = useRef(null);
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      setShowLoginPrompt(false);
+    }
+  }, [isAuthenticated]);
+
+  useEffect(() => {
+    return () => {
+      if (callTimerRef.current) {
+        clearTimeout(callTimerRef.current);
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isRecording) {
+      setCallStatus('idle');
+      setIsMuted(false);
+
+      if (callTimerRef.current) {
+        clearTimeout(callTimerRef.current);
+        callTimerRef.current = null;
+      }
+    }
+  }, [isRecording]);
 
   const getPublicAvatarUrl = useCallback((path) => {
     if (!path || !supabase) {
@@ -40,16 +70,7 @@ const VoiceChat = () => {
     return data?.publicUrl || null;
   }, [supabase]);
 
-  // Fetch profile data on component mount
-  useEffect(() => {
-    if (slug) {
-      fetchProfile();
-    }
-  }, [slug, fetchProfile]);
-
   // Fetch user profile from Supabase
-
-
   const fetchProfile = useCallback(async () => {
     try {
       setLoading(true);
@@ -71,7 +92,7 @@ const VoiceChat = () => {
       if (slugCandidates.length > 0) {
         const { data: profileMatches, error: profileError } = await supabase
           .from('profiles')
-          .select('id, username, email, full_name, bio, title, avatar_url, avatar_path, created_at')
+          .select('id, username, email, full_name, bio, title, avatar_path, created_at')
           .in('username', slugCandidates)
           .limit(1);
 
@@ -140,7 +161,7 @@ const VoiceChat = () => {
           if (candidateIds.length > 0) {
             const { data: candidateProfiles, error: candidateProfileError } = await supabase
               .from('profiles')
-              .select('id, username, email, full_name, bio, title, avatar_url, avatar_path, created_at')
+              .select('id, username, email, full_name, bio, title, avatar_path, created_at')
               .in('id', candidateIds);
 
             if (candidateProfileError) {
@@ -337,6 +358,14 @@ const VoiceChat = () => {
   }, [getPublicAvatarUrl, slug, supabase]);
 
 
+  // Fetch profile data on component mount
+  useEffect(() => {
+    if (slug) {
+      fetchProfile();
+    }
+  }, [slug, fetchProfile]);
+
+
 
   // Generate title from name and expertise
   const generateTitle = (name, expertiseAreas) => {
@@ -490,14 +519,33 @@ const VoiceChat = () => {
 
   // Handle voice recording
   const handleVoiceRecord = () => {
+    if (!isAuthenticated) {
+      setShowLoginPrompt(true);
+      return;
+    }
+
+    setShowLoginPrompt(false);
+
+    if (callTimerRef.current) {
+      clearTimeout(callTimerRef.current);
+      callTimerRef.current = null;
+    }
+
     if (isRecording) {
       setIsRecording(false);
-      // Here you would stop recording and send to your voice processing API
+      setCallStatus('idle');
+      setIsMuted(false);
       console.log('Stopping voice recording...');
     } else {
       setIsRecording(true);
-      // Here you would start voice recording
+      setCallStatus('connecting');
+      setIsMuted(false);
       console.log('Starting voice recording...');
+
+      callTimerRef.current = setTimeout(() => {
+        setCallStatus('in-call');
+        callTimerRef.current = null;
+      }, 600);
     }
   };
 
@@ -610,12 +658,12 @@ const VoiceChat = () => {
 
           {/* Action Buttons */}
           <div className="profile-actions">
-            <button 
+            <button
               onClick={handleVoiceRecord}
               className={`btn btn-primary btn-lg voice-btn ${isRecording ? 'recording' : ''}`}
             >
               {isRecording ? (
-                <>Recording...</>
+                <>End Call</>
               ) : (
                 <>Start Call</>
               )}
@@ -624,6 +672,53 @@ const VoiceChat = () => {
               Open Chat
             </button>
           </div>
+
+          {showLoginPrompt && (
+            <div className="call-login-prompt" role="alert">
+              <p>
+                Please sign in to start a voice call with {profile.name.split(' ')[0]}.
+              </p>
+              <div className="call-login-actions">
+                <Link to="/login" className="btn btn-primary btn-sm">Sign In</Link>
+                <Link to="/register" className="btn btn-secondary btn-sm">Create Account</Link>
+              </div>
+            </div>
+          )}
+
+          {isRecording && (
+            <div className="call-interface" role="status" aria-live="polite">
+              <div className="call-status">
+                <span className={`call-status-indicator ${callStatus}`} aria-hidden="true" />
+                <div>
+                  <p className="call-status-title">
+                    {callStatus === 'connecting' ? 'Connecting call...' : 'Call in progress'}
+                  </p>
+                  <p className="call-status-description">
+                    {callStatus === 'connecting'
+                      ? `Setting up a secure connection with ${profile.name}.`
+                      : `You are connected with ${profile.name}.`}
+                  </p>
+                </div>
+              </div>
+              <div className="call-controls">
+                <button
+                  type="button"
+                  className={`mute-btn ${isMuted ? 'active' : ''}`}
+                  onClick={() => setIsMuted((prev) => !prev)}
+                  aria-pressed={isMuted}
+                >
+                  {isMuted ? 'Unmute' : 'Mute'}
+                </button>
+                <button
+                  type="button"
+                  className="end-call-btn"
+                  onClick={handleVoiceRecord}
+                >
+                  End Call
+                </button>
+              </div>
+            </div>
+          )}
         </div>
 
         {/* Main Content */}
@@ -885,6 +980,120 @@ const VoiceChat = () => {
         @keyframes pulse {
           0%, 100% { opacity: 1; }
           50% { opacity: 0.8; }
+        }
+
+        .call-login-prompt {
+          margin-top: var(--space-4);
+          padding: var(--space-4);
+          border-radius: var(--radius-lg);
+          background: var(--error-100);
+          border: 1px solid rgba(239, 68, 68, 0.25);
+          color: var(--gray-700);
+        }
+
+        .call-login-prompt p {
+          margin-bottom: var(--space-3);
+          font-size: var(--text-sm);
+        }
+
+        .call-login-actions {
+          display: flex;
+          gap: var(--space-3);
+        }
+
+        .call-interface {
+          margin-top: var(--space-4);
+          padding: var(--space-4);
+          border-radius: var(--radius-xl);
+          background: var(--white);
+          border: 1px solid var(--gray-200);
+          box-shadow: var(--shadow-sm);
+        }
+
+        .call-status {
+          display: flex;
+          align-items: center;
+          gap: var(--space-4);
+        }
+
+        .call-status-title {
+          font-size: var(--text-lg);
+          font-weight: var(--font-weight-semibold);
+          color: var(--gray-900);
+          margin-bottom: var(--space-1);
+        }
+
+        .call-status-description {
+          font-size: var(--text-sm);
+          color: var(--gray-600);
+        }
+
+        .call-status-indicator {
+          width: 14px;
+          height: 14px;
+          border-radius: 50%;
+          background: var(--warning-500);
+          box-shadow: 0 0 0 6px rgba(245, 158, 11, 0.15);
+          animation: call-pulse 1.5s infinite ease-in-out;
+        }
+
+        .call-status-indicator.in-call {
+          background: var(--success-500);
+          box-shadow: 0 0 0 6px rgba(16, 185, 129, 0.2);
+        }
+
+        .call-status-indicator.idle {
+          background: var(--gray-400);
+          box-shadow: none;
+          animation: none;
+        }
+
+        @keyframes call-pulse {
+          0%, 100% { opacity: 0.8; }
+          50% { opacity: 1; }
+        }
+
+        .call-controls {
+          margin-top: var(--space-4);
+          display: flex;
+          gap: var(--space-3);
+        }
+
+        .mute-btn,
+        .end-call-btn {
+          flex: 1;
+          padding: var(--space-3) var(--space-4);
+          border-radius: var(--radius-lg);
+          border: none;
+          font-size: var(--text-base);
+          font-weight: var(--font-weight-medium);
+          cursor: pointer;
+          transition: all var(--transition-fast);
+        }
+
+        .mute-btn {
+          background: var(--gray-100);
+          color: var(--gray-700);
+        }
+
+        .mute-btn:hover {
+          background: var(--gray-200);
+        }
+
+        .mute-btn.active {
+          background: var(--gray-300);
+          color: var(--gray-900);
+        }
+
+        .end-call-btn {
+          background: var(--error-500);
+          color: var(--white);
+          box-shadow: var(--shadow-sm);
+        }
+
+        .end-call-btn:hover {
+          background: #dc2626;
+          box-shadow: var(--shadow-md);
         }
 
         /* Main Content */


### PR DESCRIPTION
## Summary
- update explore page Supabase profile queries to match the profiles schema and fall back to the public directory when tenant chatbot data is unavailable
- require users to be authenticated before starting a voice call and surface a login prompt when needed
- display an in-call interface with status feedback and controls once a call begins
- fix the VoiceChat profile fetch effect order so assistant pages load without triggering the error boundary when navigated from Explore

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d030a66b6883339539e08876733f24