### PR TITLE
Display full names across assistant experiences

### DIFF
--- a/src/components/common/Navbar.js
+++ b/src/components/common/Navbar.js
@@ -9,7 +9,8 @@ import {
   getUserEmail,
   getUserInitials,
   getUserUsername,
-  getUserAvatarUrl
+  getUserAvatarUrl,
+  getUserFullName
 } from '../../utils/userDisplay';
 
 /**
@@ -93,7 +94,8 @@ const Navbar = () => {
   ];
 
   const navItems = isAuthenticated ? authenticatedNavItems : publicNavItems;
-  const displayName = getUserDisplayName(user) || getUserEmail(user) || 'User';
+  const fullName = getUserFullName(user);
+  const displayName = fullName || getUserDisplayName(user) || getUserEmail(user) || 'User';
   const displayEmail = getUserEmail(user);
   const username = getUserUsername(user);
   const avatarInitial = getUserInitials(user, 1);

--- a/src/components/dashboard/Dashboard.js
+++ b/src/components/dashboard/Dashboard.js
@@ -11,6 +11,7 @@ import DashboardOverview from './DashboardOverview';
 import TrainingDashboard from './TrainingDashboard';
 import WidgetGenerator from './WidgetGenerator';
 import SettingsTab from './SettingsTab';
+import { getUserFullName } from '../../utils/userDisplay';
 
 /**
  * Main Dashboard Component
@@ -170,7 +171,7 @@ const Dashboard = () => {
           <div className="header-content">
             <div>
               <h1 className="dashboard-title">
-                Welcome back, {user?.user_metadata?.full_name?.split(' ')[0] || user?.email || 'User'}!
+                Welcome back, {getUserFullName(user) || user?.email || 'User'}!
               </h1>
               <p className="dashboard-subtitle">
                 Manage your AI assistant, review performance, and optimize your voice experience.

--- a/src/components/dashboard/DashboardOverview.js
+++ b/src/components/dashboard/DashboardOverview.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import {
   getUserDisplayName,
+  getUserFullName,
   getUserProfileUrl,
   getUserUsername
 } from '../../utils/userDisplay';
@@ -18,6 +19,7 @@ const DashboardOverview = ({ user, dashboardData, onRefresh }) => {
 
   const [copyStatus, setCopyStatus] = useState('idle');
 
+  const fullName = getUserFullName(user);
   const displayName = getUserDisplayName(user);
   const username = getUserUsername(user);
   const profileUrl = useMemo(() => getUserProfileUrl(user), [user]);
@@ -121,13 +123,13 @@ const DashboardOverview = ({ user, dashboardData, onRefresh }) => {
         <div>
           <h2>Dashboard Overview</h2>
           <p>
-            Welcome back, {displayName.split(' ')[0] || 'User'}! Track your training footprint and recent activity at a glance.
+            Welcome back, {fullName || displayName || 'User'}! Track your training footprint and recent activity at a glance.
           </p>
         </div>
         <div className="overview-actions">
           <div className="share-profile">
             <div className="share-text">
-              <span className="share-label">Share your dashboard</span>
+              <span className="share-label">Share your AI Voice</span>
               <span className="share-value">
                 {profileUrl || 'Complete your profile to unlock sharing'}
               </span>
@@ -145,7 +147,7 @@ const DashboardOverview = ({ user, dashboardData, onRefresh }) => {
                 ? 'Link Copied!'
                 : copyStatus === 'error'
                 ? 'Copy Failed'
-                : 'Copy Dashboard Link'}
+                : 'Copy AI Voice Link'}
             </button>
           </div>
           {onRefresh && (

--- a/src/components/explore/ExplorePage.js
+++ b/src/components/explore/ExplorePage.js
@@ -6,6 +6,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../../context/AuthContext';
 import LoadingSpinner from '../common/LoadingSpinner';
 import { buildProfileSlug, isPermissionError } from '../../utils/slugUtils';
+import { formatPossessiveName } from '../../utils/userDisplay';
 
 /**
  * ExplorePage Component
@@ -40,6 +41,17 @@ const buildDisplayName = (...candidates) => {
     }
   }
   return 'Aura Assistant';
+};
+
+const buildAssistantTitle = (name) => {
+  const baseName = sanitizeDisplayText(name) || 'Aura Assistant';
+  const possessive = formatPossessiveName(baseName);
+  if (possessive) {
+    return `${possessive} AI Assistant`;
+  }
+
+  const fallbackPossessive = formatPossessiveName('Aura Assistant');
+  return `${fallbackPossessive || 'Aura Assistant'} AI Assistant`;
 };
 
 const ExplorePage = () => {
@@ -125,7 +137,7 @@ const ExplorePage = () => {
           fullName: fullName || displayName,
           username,
           slug,
-          title: profile.title || `${(fullName || displayName).split(' ')[0] || displayName}'s AI Assistant`,
+          title: profile.title || buildAssistantTitle(fullName || displayName),
           category: 'business',
           description: profile.bio || 'Professional AI assistant ready to help you.',
           bio: profile.bio || '',
@@ -380,7 +392,7 @@ const ExplorePage = () => {
           fullName: fullName || displayName,
           username,
           slug,
-          title: personaSettings.title || profile?.title || `${resolvedName.split(' ')[0] || resolvedName}'s AI Assistant`,
+          title: personaSettings.title || profile?.title || buildAssistantTitle(fullName || resolvedName),
           category,
           description,
           bio: personaSettings.bio || profile?.bio || '',

--- a/src/utils/userDisplay.js
+++ b/src/utils/userDisplay.js
@@ -65,6 +65,20 @@ export const getUserFullName = (user) => {
   return '';
 };
 
+export const formatPossessiveName = (name) => {
+  if (!isNonEmptyString(name)) {
+    return '';
+  }
+
+  const trimmed = name.trim();
+  if (!trimmed) {
+    return '';
+  }
+
+  const suffix = /s$/i.test(trimmed) ? "'" : "'s";
+  return `${trimmed}${suffix}`;
+};
+
 export const getUserUsername = (user) => {
   const metadata = getMetadata(user);
   const candidates = [


### PR DESCRIPTION
## Summary
- ensure authenticated UI surfaces use the user's full name instead of usernames for prominent labels
- update assistant listings and detail views to generate "Full Name's AI Assistant" titles when a custom title is unavailable
- refresh dashboard share messaging to promote sharing an AI voice and adjust copy button text

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68d05918eb308333abb134ae5d3fff5d