### PR TITLE
Route start call button to slugged voice session

### DIFF
--- a/frontend/src/components/explore/VoiceChat.js
+++ b/frontend/src/components/explore/VoiceChat.js
@@ -611,17 +611,23 @@ const VoiceChat = () => {
     }
   };
 
-  // Navigate to production voice chat (HTTP-based, more stable)
+  // Navigate to dedicated voice call session for this assistant
   const handleStartCall = () => {
     if (!isAuthenticated) {
       setShowLoginPrompt(true);
       return;
     }
 
+    const targetSlug = profile?.slug || slug;
+    if (!targetSlug) {
+      return;
+    }
+
     setShowLoginPrompt(false);
 
-    // Use the improved ProductionVoiceChat instead of WebSocket-based VoiceCallSession
-    navigate(`/voice`);
+    navigate(`/chat/${targetSlug}/call`, {
+      state: profile ? { profile } : undefined,
+    });
   };
 
   // Format date


### PR DESCRIPTION
## Summary
- update the Start Call action on the assistant profile to target the `/chat/:slug/call` route instead of the generic production voice view
- pass along the loaded profile details when navigating so the modern voice call session can render with the correct assistant context

## Testing
- not run (npm dependencies cannot be installed in this environment: npm registry returns 403 for typescript@4.9.5)


------
https://chatgpt.com/codex/tasks/task_e_68d7e55f2e1c83338302da53d0f56af4