### PR TITLE
Propagate voice preference to voice chat flows

### DIFF
--- a/frontend/src/components/explore/VoiceChat.js
+++ b/frontend/src/components/explore/VoiceChat.js
@@ -374,6 +374,12 @@ const VoiceChat = () => {
       const conversationsCount = conversations.length;
       const totalMessages = conversations.reduce((sum, conv) => sum + (conv.message_count || 0), 0);
 
+      const voicePreference =
+        matchedUser.voice_preference ||
+        personaSettings.voice_preference ||
+        profileDetails?.voice_preference ||
+        null;
+
       const processedProfile = {
         id: matchedUser.user_id,
         name: displayName,
@@ -401,7 +407,8 @@ const VoiceChat = () => {
         suggestedQuestions: generateSuggestedQuestions(expertiseAreas),
         keyTopics: conversations
           .flatMap(conv => Array.isArray(conv.key_topics) ? conv.key_topics : [])
-          .slice(0, 6)
+          .slice(0, 6),
+        voicePreference,
       };
 
       setAvatarError(false);


### PR DESCRIPTION
## Summary
- expose each assistant's voice preference on the processed profile payload
- include the resolved ElevenLabs voice identifier on voice synthesis requests across the voice chat surfaces
- add fallback synthesis in the call session when the websocket omits audio

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8075f41208333af8743cdbc42db1c