### PR TITLE
Fix syntax error in VoiceChat component header comment

### DIFF
--- a/frontend/src/components/explore/VoiceCallSession.js
+++ b/frontend/src/components/explore/VoiceCallSession.js
@@ -453,7 +453,7 @@ const VoiceCallSession = () => {
             ...prev,
             {
               speaker: 'System',
-              text: 'We could not play the assistant's audio reply. Please check your volume or try again.',
+              text: "We could not play the assistant's audio reply. Please check your volume or try again.",
               timestamp: new Date(),
             },
           ]);

--- a/frontend/src/components/explore/VoiceChat.js
+++ b/frontend/src/components/explore/VoiceChat.js
@@ -1,4 +1,4 @@
-/ Aura Voice AI - Individual Profile & Voice Chat Component
+// Aura Voice AI - Individual Profile & Voice Chat Component
 // =========================================================
 
 import React, { useState, useEffect, useCallback, useMemo } from 'react';


### PR DESCRIPTION
## Summary
- convert the top banner text in `VoiceChat.js` into a proper comment so the file parses again

## Testing
- npm run build *(fails: react-scripts not found in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9d241b2ec8333a6fd8f59c3d3e620