### PR TITLE
Fix voice assistant key fallback in voice chat

### DIFF
--- a/frontend/src/components/explore/SimpleVoiceChat.js
+++ b/frontend/src/components/explore/SimpleVoiceChat.js
@@ -227,25 +227,81 @@ const SimpleVoiceChat = () => {
       },
       body: params
     });
-    
+
     if (!response.ok) {
       throw new Error(`Synthesis failed: ${response.status}`);
     }
-    
-    const result = await response.json();
-    
-    if (result.success && result.audio) {
-      // Play audio
-      const audioBytes = Uint8Array.from(atob(result.audio), c => c.charCodeAt(0));
-      const audioBlob = new Blob([audioBytes], { type: 'audio/mpeg' });
-      const audioUrl = URL.createObjectURL(audioBlob);
-      const audio = new Audio(audioUrl);
-      
+
+    const contentType = (response.headers.get('content-type') || '').toLowerCase();
+
+    let audioUrl = '';
+    let cleanup = () => {};
+
+    if (contentType.includes('application/json')) {
+      const result = await response.json();
+
+      if (result?.success === false) {
+        throw new Error(result?.message || 'Speech synthesis unavailable.');
+      }
+
+      const payloadBase64 = result?.audio || result?.audioContent || '';
+      const payloadUrl = result?.audio_url || result?.url || '';
+      const payloadContentType =
+        result?.content_type || result?.contentType || result?.mime_type || 'audio/mpeg';
+
+      if (payloadBase64) {
+        const binary = atob(payloadBase64);
+        const bytes = new Uint8Array(binary.length);
+        for (let i = 0; i < binary.length; i += 1) {
+          bytes[i] = binary.charCodeAt(i);
+        }
+        const audioBlob = new Blob([bytes], { type: payloadContentType });
+        audioUrl = URL.createObjectURL(audioBlob);
+        cleanup = () => URL.revokeObjectURL(audioUrl);
+      } else if (payloadUrl) {
+        audioUrl = payloadUrl;
+      } else {
+        throw new Error('No audio data received from synthesis service');
+      }
+    } else if (contentType.includes('audio/')) {
+      const audioBlob = await response.blob();
+      audioUrl = URL.createObjectURL(audioBlob);
+      cleanup = () => URL.revokeObjectURL(audioUrl);
+    } else {
+      const unexpectedBody = await response.text().catch(() => '');
+      throw new Error(
+        `Unexpected content-type from synth service: ${contentType || 'unknown'}` +
+          (unexpectedBody ? `. ${unexpectedBody}` : '')
+      );
+    }
+
+    if (!audioUrl) {
+      throw new Error('Unable to determine audio URL for playback');
+    }
+
+    const audio = new Audio(audioUrl);
+    audio.preload = 'auto';
+
+    const handleCleanup = () => {
+      cleanup();
+      audio.removeEventListener('ended', handleCleanup);
+      audio.removeEventListener('error', handleError);
+    };
+
+    const handleError = () => {
+      cleanup();
+      audio.removeEventListener('ended', handleCleanup);
+      audio.removeEventListener('error', handleError);
+    };
+
+    audio.addEventListener('ended', handleCleanup);
+    audio.addEventListener('error', handleError);
+
+    try {
       await audio.play();
-      
-      audio.onended = () => {
-        URL.revokeObjectURL(audioUrl);
-      };
+    } catch (playError) {
+      handleError();
+      throw playError;
     }
   };
 

--- a/frontend/src/components/explore/VoiceCallSession.js
+++ b/frontend/src/components/explore/VoiceCallSession.js
@@ -453,7 +453,7 @@ const VoiceCallSession = () => {
             ...prev,
             {
               speaker: 'System',
-              text: 'We could not play the assistant's audio reply. Please check your volume or try again.',
+              text: 'We could not play the assistant\'s audio reply. Please check your volume or try again.',
               timestamp: new Date(),
             },
           ]);
@@ -520,7 +520,7 @@ const VoiceCallSession = () => {
           ...prev,
           {
             speaker: 'System',
-            text: 'We couldn't hear anything. Please try speaking again.',
+            text: 'We couldn\'t hear anything. Please try speaking again.',
             timestamp: new Date(),
           },
         ]);

--- a/frontend/src/components/explore/VoiceCallSession.js
+++ b/frontend/src/components/explore/VoiceCallSession.js
@@ -320,38 +320,60 @@ const VoiceCallSession = () => {
           }
         }
 
-        const result = await response.json();
-        console.log('✅ Synthesis result:', { 
-          success: result.success, 
-          hasAudio: !!result.audio,
-          audioLength: result.audio ? result.audio.length : 0
-        });
+        const contentType = (response.headers.get('content-type') || '').toLowerCase();
 
-        if (result?.success === false) {
-          throw new Error(result?.message || 'Speech synthesis unavailable.');
+        if (contentType.includes('application/json')) {
+          const result = await response.json();
+          console.log('✅ Synthesis result:', {
+            success: result.success,
+            hasAudio: !!result.audio || !!result.audioContent,
+            audioLength: result.audio ? result.audio.length : result.audioContent ? result.audioContent.length : 0
+          });
+
+          if (result?.success === false) {
+            throw new Error(result?.message || 'Speech synthesis unavailable.');
+          }
+
+          if (result?.audio) {
+            return {
+              base64: result.audio,
+              contentType: result?.content_type || result?.mime_type || 'audio/mpeg',
+            };
+          }
+
+          if (result?.audioContent) {
+            return {
+              base64: result.audioContent,
+              contentType: result?.contentType || 'audio/mpeg',
+            };
+          }
+
+          if (result?.audio_url || result?.url) {
+            return {
+              url: result.audio_url || result.url,
+              contentType: result?.content_type || result?.mime_type || 'audio/mpeg',
+            };
+          }
+
+          throw new Error('No audio data received from synthesis service');
         }
 
-        if (result?.audio) {
+        if (contentType.includes('audio/')) {
+          const audioBlob = await response.blob();
+          const blobType = audioBlob.type || contentType || 'audio/mpeg';
+          const objectUrl = URL.createObjectURL(audioBlob);
           return {
-            base64: result.audio,
-            contentType: result?.content_type || result?.mime_type || 'audio/mpeg',
+            url: objectUrl,
+            contentType: blobType,
+            cleanup: () => URL.revokeObjectURL(objectUrl),
           };
         }
 
-        if (result?.audioContent) {
-          return {
-            base64: result.audioContent,
-            contentType: result?.contentType || 'audio/mpeg',
-          };
-        }
-
-        if (result?.audio_url || result?.url) {
-          return {
-            url: result.audio_url || result.url,
-          };
-        }
-
-        throw new Error('No audio data received from synthesis service');
+        const unexpectedBody = await response.text().catch(() => '');
+        throw new Error(
+          `Unexpected content-type from synth service: ${contentType || 'unknown'}` +
+            (unexpectedBody ? `. ${unexpectedBody}` : '')
+        );
 
       } catch (error) {
         console.error('❌ Speech synthesis error:', error);
@@ -374,7 +396,7 @@ const VoiceCallSession = () => {
 
   const playAssistantAudio = useCallback(
     async (text) => {
-      let objectUrlCleanup = () => {};
+      let cleanupHandler = () => {};
       try {
         const synthesisResult = await synthesizeSpeech(text);
         if (!synthesisResult) {
@@ -399,7 +421,8 @@ const VoiceCallSession = () => {
           activeAudioRef.current = null;
         }
 
-        let audioSource = synthesisResult.url || '';
+        let audioSource = synthesisResult.url || synthesisResult.audioUrl || '';
+        cleanupHandler = typeof synthesisResult.cleanup === 'function' ? synthesisResult.cleanup : () => {};
         if (synthesisResult.base64) {
           const byteCharacters = atob(synthesisResult.base64);
           const byteNumbers = new Array(byteCharacters.length);
@@ -411,7 +434,11 @@ const VoiceCallSession = () => {
             type: synthesisResult.contentType || 'audio/mpeg',
           });
           const objectUrl = URL.createObjectURL(audioBlob);
-          objectUrlCleanup = () => URL.revokeObjectURL(objectUrl);
+          const previousCleanup = cleanupHandler;
+          cleanupHandler = () => {
+            URL.revokeObjectURL(objectUrl);
+            previousCleanup();
+          };
           audioSource = objectUrl;
         }
 
@@ -432,7 +459,7 @@ const VoiceCallSession = () => {
 
         const handleComplete = () => {
           setIsAssistantSpeaking(false);
-          objectUrlCleanup();
+          cleanupHandler();
           audio.removeEventListener('ended', handleComplete);
           audio.removeEventListener('error', handleError);
           if (activeAudioRef.current === audio) {
@@ -443,7 +470,7 @@ const VoiceCallSession = () => {
         const handleError = (event) => {
           console.error('Audio playback error event:', event);
           setIsAssistantSpeaking(false);
-          objectUrlCleanup();
+          cleanupHandler();
           audio.removeEventListener('ended', handleComplete);
           audio.removeEventListener('error', handleError);
           if (activeAudioRef.current === audio) {
@@ -471,7 +498,7 @@ const VoiceCallSession = () => {
       } catch (error) {
         console.error('Audio playback error:', error);
         setIsAssistantSpeaking(false);
-        objectUrlCleanup();
+        cleanupHandler();
         activeAudioRef.current = null;
         setTranscript((prev) => [
           ...prev,

--- a/frontend/src/components/explore/VoiceChat.js
+++ b/frontend/src/components/explore/VoiceChat.js
@@ -1,4 +1,4 @@
-/ Aura Voice AI - Individual Profile & Voice Chat Component
+// Aura Voice AI - Individual Profile & Voice Chat Component
 // =========================================================
 
 import React, { useState, useEffect, useCallback, useMemo } from 'react';

--- a/frontend/src/components/explore/VoiceChat.js
+++ b/frontend/src/components/explore/VoiceChat.js
@@ -338,19 +338,27 @@ const VoiceChat = () => {
       const cachedAssistantKey = cachedAssistantKeyValue
         ? cachedAssistantKeyValue.toString().trim()
         : '';
-      const cachedAssistantKeyLower = cachedAssistantKey.toLowerCase();
       const sanitizedCachedAssistantKey = sanitizeSlug(cachedAssistantKey);
+      const cachedAssistantKeyLower = cachedAssistantKey.toLowerCase();
 
       const sanitizedSlugTargets = [sanitizedResolvedSlug, sanitizedUrlSlug].filter(Boolean);
-      const cachedAssistantMatchesSlug =
-        sanitizedSlugTargets.length === 0
-          ? Boolean(sanitizedCachedAssistantKey)
-          : sanitizedSlugTargets.some(
+      const sanitizedKeyMatchesSlug =
+        sanitizedCachedAssistantKey && sanitizedSlugTargets.length > 0
+          ? sanitizedSlugTargets.some(target => target === sanitizedCachedAssistantKey)
+          : Boolean(sanitizedCachedAssistantKey);
+
+      const rawKeyMatchesSlug =
+        cachedAssistantKey && sanitizedSlugTargets.length > 0
+          ? sanitizedSlugTargets.some(
               target => target === cachedAssistantKey || target === cachedAssistantKeyLower
-            );
+            )
+          : Boolean(cachedAssistantKey);
 
       const shouldFetchVoicePreference =
-        !voicePreference || !sanitizedCachedAssistantKey || !cachedAssistantMatchesSlug;
+        !voicePreference ||
+        !sanitizedCachedAssistantKey ||
+        !sanitizedKeyMatchesSlug ||
+        !rawKeyMatchesSlug;
 
       const normalizeVoicePreference = (preference) => {
         if (!preference) {
@@ -385,29 +393,40 @@ const VoiceChat = () => {
       };
 
       if (shouldFetchVoicePreference) {
-        const assistantKeyCandidates = new Set(
-          [
-            personaSettings.assistant_key,
-            personaSettings.assistantKey,
-            personaSettings.slug,
-            personaSettings.slug?.toString().trim().toLowerCase(),
-            personaSettings.identifier,
-            personaSettings.voice_assistant_key,
-            personaSettings.voiceAssistantKey,
-            personaSettings.id,
-            personaSettings.key,
-            profileDetails?.username,
-            profileDetails?.username?.toString().trim().toLowerCase(),
-            matchedUser.user_id,
-            matchedUser.user_id ? matchedUser.user_id.toString() : '',
-            matchedUser.email?.split('@')[0],
-            resolvedSlug,
-            slug,
-          ]
-            .concat(Array.from(slugCandidates))
-            .map((value) => (value ? value.toString().trim() : ''))
-            .filter(Boolean)
-        );
+        const assistantKeyCandidates = new Set();
+        const candidateValues = [
+          personaSettings.assistant_key,
+          personaSettings.assistantKey,
+          personaSettings.slug,
+          personaSettings.slug?.toString().trim().toLowerCase(),
+          personaSettings.identifier,
+          personaSettings.voice_assistant_key,
+          personaSettings.voiceAssistantKey,
+          personaSettings.id,
+          personaSettings.key,
+          profileDetails?.username,
+          profileDetails?.username?.toString().trim().toLowerCase(),
+          matchedUser.user_id,
+          matchedUser.user_id ? matchedUser.user_id.toString() : '',
+          matchedUser.email?.split('@')[0],
+          resolvedSlug,
+          slug,
+          ...Array.from(slugCandidates),
+        ];
+
+        candidateValues.forEach((value) => {
+          if (value === null || value === undefined) {
+            return;
+          }
+          const trimmed = value.toString().trim();
+          if (trimmed) {
+            assistantKeyCandidates.add(trimmed);
+            const sanitizedCandidate = sanitizeSlug(trimmed);
+            if (sanitizedCandidate) {
+              assistantKeyCandidates.add(sanitizedCandidate);
+            }
+          }
+        });
 
         if (assistantKeyCandidates.size > 0) {
           let voicePrefQuery = supabase
@@ -433,18 +452,25 @@ const VoiceChat = () => {
             }
           } else if (voicePrefMatches && voicePrefMatches.length > 0) {
             const latestVoicePreference = voicePrefMatches[0];
-            const fetchedAssistantKey =
-              latestVoicePreference.assistant_key ||
-              latestVoicePreference.assistantKey ||
+            const supabaseAssistantKeyRaw =
+              latestVoicePreference.assistant_key || latestVoicePreference.assistantKey || '';
+            const trimmedSupabaseAssistantKey = supabaseAssistantKeyRaw
+              ? supabaseAssistantKeyRaw.toString().trim()
+              : '';
+            const mergedAssistantKey =
+              sanitizeSlug(trimmedSupabaseAssistantKey) ||
+              sanitizedCachedAssistantKey ||
               sanitizedResolvedSlug ||
               sanitizedUrlSlug ||
+              trimmedSupabaseAssistantKey ||
+              cachedAssistantKey ||
               null;
 
             voicePreference = {
               ...(voicePreference || {}),
               ...latestVoicePreference,
-              assistant_key: fetchedAssistantKey,
-              assistantKey: fetchedAssistantKey,
+              assistant_key: mergedAssistantKey,
+              assistantKey: mergedAssistantKey,
             };
           }
         }
@@ -452,7 +478,11 @@ const VoiceChat = () => {
 
       const normalizedVoicePreference = normalizeVoicePreference(voicePreference);
 
-      const assistantKey =
+      const sanitizedPreferenceAssistantKey = sanitizeSlug(
+        normalizedVoicePreference?.assistant_key || normalizedVoicePreference?.assistantKey || ''
+      );
+
+      const fallbackAssistantKeyValue =
         normalizedVoicePreference?.assistant_key ||
         normalizedVoicePreference?.assistantKey ||
         personaSettings.assistant_key ||
@@ -460,8 +490,21 @@ const VoiceChat = () => {
         profileDetails?.username ||
         resolvedSlug;
 
+      const fallbackAssistantKey = fallbackAssistantKeyValue
+        ? fallbackAssistantKeyValue.toString().trim()
+        : '';
+
+      const assistantKey =
+        sanitizedPreferenceAssistantKey ||
+        sanitizeSlug(fallbackAssistantKey) ||
+        fallbackAssistantKey ||
+        sanitizedResolvedSlug ||
+        sanitizedUrlSlug ||
+        resolvedSlug;
+
       const voicePreferenceDetails = normalizedVoicePreference
         ? {
+            ...normalizedVoicePreference,
             voice_id:
               normalizedVoicePreference.voice_id ||
               normalizedVoicePreference.voiceId ||
@@ -476,8 +519,8 @@ const VoiceChat = () => {
               normalizedVoicePreference.voice_model ||
               normalizedVoicePreference.params?.model ||
               'eleven_monolingual_v1',
-            assistant_key: normalizedVoicePreference.assistant_key || assistantKey || resolvedSlug,
-            ...normalizedVoicePreference,
+            assistant_key: assistantKey,
+            assistantKey,
           }
         : null;
 


### PR DESCRIPTION
## Summary
- refresh cached voice preferences when the assistant key no longer matches the sanitized profile slug
- merge the fetched assistant voice preference so the assistant key fields carry the hyphenated identifier

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9d8bbd61883339208161e32e2c40e